### PR TITLE
Add Android CI + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,42 @@
+name: Android CI
+on:   
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '*' ]
+  workflow_dispatch:
+jobs:
+  gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Root
+      uses: actions/checkout@v2
+
+    - name: Checkout submodules
+      shell: bash
+      run: |
+       git config --global url."https://github.com/".insteadOf "git@github.com:"
+       auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+       git submodule sync --recursive
+       git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
+    - uses: actions/setup-java@v2
+      with:
+        distribution: temurin
+        java-version: 11
+  
+    - name: Cache Gradle and wrapper
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Make Gradle executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
Adds a basic CI GitHub action config & dependabot.

The "Android CI" action runs on all pushes to master & all pull requests.